### PR TITLE
Highscore improvements

### DIFF
--- a/src/css/agency.min.css
+++ b/src/css/agency.min.css
@@ -986,6 +986,11 @@ strong {
     text-align: center;
 }
 
+.highscores .avatar > img {
+    width: 1em;
+    height: 1em;
+}
+
 .highscores th {
     padding: 5px;
 }

--- a/src/highscores.html
+++ b/src/highscores.html
@@ -48,10 +48,9 @@
             <div class="col-md-12">
                 <form id="highscoreOnUsername">
                     <div class="input-group">
-                        <input class="form-control" id="username" placeholder="Username" required>
-                        <div class="input-group-btn">
-                            <button class="btn btn-default" style="cursor: pointer"><span class="fa fa-search"></span></button>
-                        </div>
+                        <select class="form-control" id="username">
+                            <option value="">All Players</option>
+                        </select>
                     </div>
                 </form>
             </div>

--- a/src/highscores.html
+++ b/src/highscores.html
@@ -36,8 +36,8 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/apply.html" target="_blank">Apply</a></li>
-                    <li class="nav-item"><a class="nav-link navactive" href="/highscores.html">Highscores</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/apply" target="_blank">Apply</a></li>
+                    <li class="nav-item"><a class="nav-link navactive" href="/highscores">Highscores</a></li>
                 </ul>
             </div>
         </div>

--- a/src/js/highscore.js
+++ b/src/js/highscore.js
@@ -153,16 +153,20 @@ var highscore = (function () {
                 .append($("<tbody>"))));
     }
 
-    function addHighscorePlayer(rank, playername, score) {
-        $("tbody").last().append($("<tr>")
+    function makePlayerScoreRow(rank, playername, score) {
+        const scoreCellText = typeof score === 'undefined' ? '-' : score;
+        const avatarCell = typeof playername === 'undefined' ? ''
+            : $("<img>").attr("alt", "Avatar of " + playername).attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[playername] + '?overlay=true');
+        const playerCell = typeof playername === 'undefined' ? '-' : $("<a href='#'>").addClass("playername").text(playername);
+
+        return $("<tr>")
             .append($("<td>").addClass("rank")
                 .text(rank))
             .append($("<td>").addClass("avatar")
-                .append($("<img>").attr("alt", "Avatar of " + playername)
-                    .attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[playername])))
+                .append(avatarCell))
             .append($("<td>")
-                .append($("<a href='#'>").addClass("playername").text(playername)))
-            .append($("<td>").text(score)));
+                .append(playerCell))
+            .append($("<td>").text(scoreCellText));
     }
 
     function higscoreToHtml() {
@@ -178,23 +182,15 @@ var highscore = (function () {
                             if (nb === "scores") {
                                 for (var i = 0; i < 15; i++) {
                                     if (obj.length > i) {
-                                        addHighscorePlayer(i + 1, obj[i].playerName, obj[i].score);
+                                        $("tbody").last().append(makePlayerScoreRow(i + 1, obj[i].playerName, obj[i].score));
                                     } else {
-                                        addHighscorePlayer(i + 1, "-", "-");
+                                        $("tbody").last().append(makePlayerScoreRow(i + 1));
                                     }
                                 }
                             }
                         hue += 40;
                     })
                 })
-            }
-        })
-    }
-
-    function hasPlayerPlayedOnServer(playername) {
-        $.each(highscoreObject, function (nb, obj) {
-            if (nb === "scores") {
-
             }
         })
     }
@@ -221,22 +217,12 @@ var highscore = (function () {
                     })
 
                     if(highScoreInfo.found) {
-                        $("tbody").last().append($("<tr>").addClass("usernameHighlight")
-                            .append($("<td>").addClass("rank")
-                                .text(highScoreInfo.index))
-                            .append($("<td>").addClass("avatar")
-                                .append($("<img>").attr("alt", "Avatar of " + highScoreInfo.playerName)
-                                    .attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[highScoreInfo.playerName])))
-                            .append($("<td>")
-                                .append($("<a href='#'>").addClass("playername").text(highScoreInfo.playerName)))
-                            .append($("<td>").text(highScoreInfo.score)));
-                        console.log("FOUND");
+                        $("tbody").last().append(makePlayerScoreRow(highScoreInfo.index, highScoreInfo.playerName, highScoreInfo.score).addClass("usernameHighlight"));
                     } else {
                         $("tbody").last().append($("<tr>").addClass("usernameHighlight")
                             .append($("<td>").addClass("rank")
                                 .attr("colspan", "4")
                                 .text("Not scored yet")));
-                        console.log("NOT FOUND");
                     }
                     hue += 40;
                 });

--- a/src/js/highscore.js
+++ b/src/js/highscore.js
@@ -3,6 +3,8 @@ var startTime;
 var hue = 0;
 var highscoreOnName = [];
 var highscoreSort = ["Playtime", "Blocks traveled", "Stone mined", "Diamonds mined", "Mobs killed", "Deaths", "Damage taken", "Obsidian mined", "Villagers traded"];
+var playerList;
+var uuidByPlayerName;
 
 var highscore = (function () {
 
@@ -20,6 +22,7 @@ var highscore = (function () {
         makeHighscoreObject("highscores.json");
         initializePlayerList();
         calculateDeathsPerDay();
+        shortenPlayedMinutesText();
 
         higscoreToHtml();
         calculateTimeAndToHtml();
@@ -34,6 +37,10 @@ var highscore = (function () {
         playerList = highscoreObject.UUID.map(u => u.lastKnownName).sort((playerA, playerB) => {
             return playerA.toLowerCase().localeCompare(playerB.toLowerCase());
         });
+        uuidByPlayerName = highscoreObject.UUID.reduce((result, item) => {
+            result[item.lastKnownName] = item.UUID;
+            return result;
+        }, {});
     }
 
     /**
@@ -94,6 +101,12 @@ var highscore = (function () {
         }, {});
     }
 
+    function shortenPlayedMinutesText() {
+        for(let score of highscoreObject.scores["ts_PlayedMinutes"].scores) {
+            score.score = score.score.replace(/minutes$/, 'min');
+        }
+    }
+
     function makeHighscoreObject(file) {
         var rawFile = new XMLHttpRequest();
         var timestamp = Math.floor(Date.now() / (1000 * 60))
@@ -133,6 +146,8 @@ var highscore = (function () {
                         .append($("<th>")
                             .text("rank"))
                         .append($("<th>")
+                            .text(""))
+                        .append($("<th>")
                             .text("player"))
                         .append($("<th>")
                             .text("amount"))))
@@ -143,6 +158,9 @@ var highscore = (function () {
         $("tbody").last().append($("<tr>")
             .append($("<td>").addClass("rank")
                 .text(rank))
+            .append($("<td>").addClass("avatar")
+                .append($("<img>").attr("alt", "Avatar of " + playername)
+                    .attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[playername])))
             .append($("<td>")
                 .append($("<a href='#'>").addClass("playername").text(playername)))
             .append($("<td>").text(score)));
@@ -209,6 +227,9 @@ var highscore = (function () {
                         $("tbody").last().append($("<tr>").addClass("usernameHighlight")
                             .append($("<td>").addClass("rank")
                                 .text(obj[0]))
+                            .append($("<td>").addClass("avatar")
+                                .append($("<img>").attr("alt", "Avatar of " + obj[1])
+                                    .attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[obj[1]])))
                             .append($("<td>")
                                 .append($("<a href='#'>").addClass("playername").text(obj[1])))
                             .append($("<td>").text(obj[2])));

--- a/src/js/highscore.js
+++ b/src/js/highscore.js
@@ -23,6 +23,7 @@ var highscore = (function () {
 
         higscoreToHtml();
         calculateTimeAndToHtml();
+        renderPlayerListToHtml();
     }
 
     //
@@ -30,7 +31,9 @@ var highscore = (function () {
     //
 
     function initializePlayerList() {
-        playerList = highscoreObject.UUID.map(u => u.lastKnownName).sort();
+        playerList = highscoreObject.UUID.map(u => u.lastKnownName).sort((playerA, playerB) => {
+            return playerA.toLowerCase().localeCompare(playerB.toLowerCase());
+        });
     }
 
     /**
@@ -106,6 +109,19 @@ var highscore = (function () {
         rawFile.send(null);
     }
 
+    //
+    // Rendering
+    //
+    function renderPlayerListToHtml() {
+        const playerSelect = document.getElementById("username");
+        for(let player of playerList) {
+            const optionElement = document.createElement("option");
+            optionElement.value = player;
+            optionElement.text = player;
+            playerSelect.appendChild(optionElement);
+        }
+    }
+
     function makeHighscoreHeader(highscorename) {
         $("#row").append($("<div>").addClass("col-md-4 p-2")
             .append($("<div>").addClass("hiheader").css("filter", "hue-rotate(" + hue + "deg)")
@@ -133,6 +149,7 @@ var highscore = (function () {
     }
 
     function higscoreToHtml() {
+        hue = 0;
         $.each(highscoreObject, function (nb, obj) {
             if (nb === "time") {
                 startTime = obj;
@@ -165,8 +182,15 @@ var highscore = (function () {
         })
     }
 
-    $('#highscoreOnUsername').submit(function () {
+    function onUserNameChange() {
+        const selectedUserName = $("#username").val();
         $("#row").empty();
+        if(selectedUserName === '') {
+            higscoreToHtml();
+            return;
+        }
+
+        hue = 0;
         highscoreOnName.length = 0;
         $.each(highscoreObject, function (nb, obj) {
             if (nb === "scores") {
@@ -174,7 +198,7 @@ var highscore = (function () {
                     makeHighscoreHeader(obj.DisplayName);
                     var found = false;
                     $.each(obj.scores, function (nb, obj) {
-                        if (obj.playerName.toLowerCase() === $("#username").val().toLowerCase()) {
+                        if (obj.playerName.toLowerCase() === selectedUserName.toLowerCase()) {
                             highscoreOnName[0] = [obj.index, obj.playerName, obj.score];
                             found = true;
                         } else if (found == false) {
@@ -193,8 +217,16 @@ var highscore = (function () {
                 })
             }
         })
+    }
+
+    $("#username").change(onUserNameChange);
+
+    $('body').on('click', '.playername', function() {
+        const playerLink = $(this);
+        $('#username').val(playerLink.text());
+        onUserNameChange();
         return false;
-    });
+    })
 
     function timeConverter(UNIX_timestamp){
       var a = new Date(UNIX_timestamp * 1000);

--- a/src/js/highscore.js
+++ b/src/js/highscore.js
@@ -1,7 +1,6 @@
 var highscoreObject;
 var startTime;
 var hue = 0;
-var highscoreOnName = [];
 var highscoreSort = ["Playtime", "Blocks traveled", "Stone mined", "Diamonds mined", "Mobs killed", "Deaths", "Damage taken", "Obsidian mined", "Villagers traded"];
 var playerList;
 var uuidByPlayerName;
@@ -209,33 +208,38 @@ var highscore = (function () {
         }
 
         hue = 0;
-        highscoreOnName.length = 0;
         $.each(highscoreObject, function (nb, obj) {
             if (nb === "scores") {
                 $.each(obj, function (nb, obj) {
                     makeHighscoreHeader(obj.DisplayName);
-                    var found = false;
+
+                    let highScoreInfo = { found: false };
                     $.each(obj.scores, function (nb, obj) {
                         if (obj.playerName.toLowerCase() === selectedUserName.toLowerCase()) {
-                            highscoreOnName[0] = [obj.index, obj.playerName, obj.score];
-                            found = true;
-                        } else if (found == false) {
-                            highscoreOnName[0] = ["-", "-", "-"]
+                            highScoreInfo = { ...obj, found: true};
                         }
                     })
-                    $.each(highscoreOnName, function (nb, obj) {
+
+                    if(highScoreInfo.found) {
                         $("tbody").last().append($("<tr>").addClass("usernameHighlight")
                             .append($("<td>").addClass("rank")
-                                .text(obj[0]))
+                                .text(highScoreInfo.index))
                             .append($("<td>").addClass("avatar")
-                                .append($("<img>").attr("alt", "Avatar of " + obj[1])
-                                    .attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[obj[1]])))
+                                .append($("<img>").attr("alt", "Avatar of " + highScoreInfo.playerName)
+                                    .attr("src", 'https://crafatar.com/avatars/' + uuidByPlayerName[highScoreInfo.playerName])))
                             .append($("<td>")
-                                .append($("<a href='#'>").addClass("playername").text(obj[1])))
-                            .append($("<td>").text(obj[2])));
-                    })
+                                .append($("<a href='#'>").addClass("playername").text(highScoreInfo.playerName)))
+                            .append($("<td>").text(highScoreInfo.score)));
+                        console.log("FOUND");
+                    } else {
+                        $("tbody").last().append($("<tr>").addClass("usernameHighlight")
+                            .append($("<td>").addClass("rank")
+                                .attr("colspan", "4")
+                                .text("Not scored yet")));
+                        console.log("NOT FOUND");
+                    }
                     hue += 40;
-                })
+                });
             }
         })
     }


### PR DESCRIPTION
Hi!

I made some small UI improvements to the highscores page.

- Add "Deaths per Day" highscore calculated from "Deaths" and "Played Minutes" (only for players with at least 24h of gameplay time)
- Select instead of Input for player name filter.
- Click on player name in table to apply filter for that player
- Show avatars in table
- Fixed links to /apply and /highscore from highscore page to avoid unnecessary redirects

For browser compatibility i assumed that current up to date browsers (edge, FF, Chrome, ...) should be enough - so i used some constructs such as let/const/for ... of which are not supported by IE11 or below. Let me know if this is a problem and i should stick to language features which are supported by older browsers.